### PR TITLE
add support for module alias discarded name

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "25.2"
-          gleam-version: "0.34.1"
+          gleam-version: "1.1.0"
           rebar3-version: "3"
           # elixir-version: "1.14.2"
       - run: gleam format --check src test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Remove `external fn` and `external type` syntax. Unsupported in Gleam since 0.31.0.
 - Add support for list with spread operator and no fixed elements, i.e. `[..]`
 - Fixed a typo so `FunctionType.paramters` is now called `FunctionType.parameters`.
+- Add support for module alias discarded name
 
 ## v0.8.2 - 2024-01-20
 

--- a/gleam.toml
+++ b/gleam.toml
@@ -16,4 +16,4 @@ glexer = "~> 1.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"
-simplifile = "~> 0.1"
+simplifile = "~> 1.0"

--- a/gleam.toml
+++ b/gleam.toml
@@ -12,7 +12,7 @@ gleam = ">= 0.32.0"
 
 [dependencies]
 gleam_stdlib = ">= 0.28.0 and < 2.0.0"
-glexer = "~> 0.5"
+glexer = "~> 1.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,14 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.33.1", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "3CEAD7B153D896499C78390B22CC968620C27500C922AED3A5DD7B536F922B25" },
-  { name = "gleeunit", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "D3682ED8C5F9CAE1C928F2506DE91625588CC752495988CBE0F5653A42A6F334" },
-  { name = "glexer", version = "0.7.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "4484942A465482A0A100936E1E5F12314DB4B5AC0D87575A7B9E9062090B96BE" },
+  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
+  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
+  { name = "glexer", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "7DDF490B891139BDE18F39A2A4DDE0683CBCB923F9472CD5C2C73DF1E56A6C13" },
   { name = "simplifile", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "8F3C94B83F691CCFACD784A4D7C1F7E5A0437D93341549B908EE3B32E3477447" },
 ]
 
 [requirements]
 gleam_stdlib = { version = ">= 0.28.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
-glexer = { version = "~> 0.5" }
+glexer = { version = "~> 1.0" }
 simplifile = { version = "~> 0.1" }

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,14 +2,15 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "gleam_stdlib", version = "0.36.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "C0D14D807FEC6F8A08A7C9EF8DFDE6AE5C10E40E21325B2B29365965D82EB3D4" },
+  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
+  { name = "gleam_stdlib", version = "0.37.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5398BD6C2ABA17338F676F42F404B9B7BABE1C8DC7380031ACB05BBE1BCF3742" },
   { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
   { name = "glexer", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "7DDF490B891139BDE18F39A2A4DDE0683CBCB923F9472CD5C2C73DF1E56A6C13" },
-  { name = "simplifile", version = "0.4.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "8F3C94B83F691CCFACD784A4D7C1F7E5A0437D93341549B908EE3B32E3477447" },
+  { name = "simplifile", version = "1.7.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "1D5DFA3A2F9319EC85825F6ED88B8E449F381B0D55A62F5E61424E748E7DDEB0" },
 ]
 
 [requirements]
 gleam_stdlib = { version = ">= 0.28.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
 glexer = { version = "~> 1.0" }
-simplifile = { version = "~> 0.1" }
+simplifile = { version = "~> 1.0" }

--- a/src/glance.gleam
+++ b/src/glance.gleam
@@ -226,7 +226,7 @@ pub type AssignmentName {
 pub type Import {
   Import(
     module: String,
-    alias: Option(String),
+    alias: Option(AssignmentName),
     unqualified_types: List(UnqualifiedImport),
     unqualified_values: List(UnqualifiedImport),
   )
@@ -522,11 +522,11 @@ fn module_name(name: String, tokens: Tokens) -> Result(#(String, Tokens), Error)
   }
 }
 
-fn optional_module_alias(tokens: Tokens) -> #(Option(String), Tokens) {
+fn optional_module_alias(tokens: Tokens) -> #(Option(AssignmentName), Tokens) {
   case tokens {
-    [#(t.As, _), #(t.Name(alias), _), ..tokens] -> #(Some(alias), tokens)
+    [#(t.As, _), #(t.Name(alias), _), ..tokens] -> #(Some(Named(alias)), tokens)
     [#(t.As, _), #(t.DiscardName(alias), _), ..tokens] -> #(
-      Some("_" <> alias),
+      Some(Discarded(alias)),
       tokens,
     )
     _ -> #(None, tokens)

--- a/src/glance.gleam
+++ b/src/glance.gleam
@@ -525,7 +525,10 @@ fn module_name(name: String, tokens: Tokens) -> Result(#(String, Tokens), Error)
 fn optional_module_alias(tokens: Tokens) -> #(Option(String), Tokens) {
   case tokens {
     [#(t.As, _), #(t.Name(alias), _), ..tokens] -> #(Some(alias), tokens)
-    [#(t.As, _), #(t.DiscardName(_), _), ..tokens] -> #(Some("_"), tokens)
+    [#(t.As, _), #(t.DiscardName(alias), _), ..tokens] -> #(
+      Some("_" <> alias),
+      tokens,
+    )
     _ -> #(None, tokens)
   }
 }

--- a/src/glance.gleam
+++ b/src/glance.gleam
@@ -1,9 +1,9 @@
 import gleam/int
 import gleam/list
 import gleam/option.{type Option, None, Some}
-import glexer/token.{type Token} as t
-import glexer.{type Position, Position}
 import gleam/result
+import glexer.{type Position, Position}
+import glexer/token.{type Token} as t
 
 type Tokens =
   List(#(Token, Position))
@@ -525,6 +525,7 @@ fn module_name(name: String, tokens: Tokens) -> Result(#(String, Tokens), Error)
 fn optional_module_alias(tokens: Tokens) -> #(Option(String), Tokens) {
   case tokens {
     [#(t.As, _), #(t.Name(alias), _), ..tokens] -> #(Some(alias), tokens)
+    [#(t.As, _), #(t.DiscardName(_), _), ..tokens] -> #(Some("_"), tokens)
     _ -> #(None, tokens)
   }
 }
@@ -559,12 +560,12 @@ fn unqualified_imports(
       ..tokens
     ]
     | [
-      #(t.Name(name), _),
-      #(t.As, _),
-      #(t.Name(alias), _),
-      #(t.Comma, _),
-      ..tokens
-    ] -> {
+        #(t.Name(name), _),
+        #(t.As, _),
+        #(t.Name(alias), _),
+        #(t.Comma, _),
+        ..tokens
+      ] -> {
       let import_ = UnqualifiedImport(name, Some(alias))
       unqualified_imports(types, [import_, ..values], tokens)
     }
@@ -578,12 +579,12 @@ fn unqualified_imports(
       ..tokens
     ]
     | [
-      #(t.Name(name), _),
-      #(t.As, _),
-      #(t.Name(alias), _),
-      #(t.RightBrace, _),
-      ..tokens
-    ] -> {
+        #(t.Name(name), _),
+        #(t.As, _),
+        #(t.Name(alias), _),
+        #(t.RightBrace, _),
+        ..tokens
+      ] -> {
       let import_ = UnqualifiedImport(name, Some(alias))
       Ok(#(list.reverse(types), list.reverse([import_, ..values]), tokens))
     }
@@ -1185,12 +1186,12 @@ fn call(
       ..tokens
     ]
     | [
-      #(t.Name(label), _),
-      #(t.Colon, _),
-      #(t.DiscardName(""), _),
-      #(t.RightParen, _),
-      ..tokens
-    ] -> {
+        #(t.Name(label), _),
+        #(t.Colon, _),
+        #(t.DiscardName(""), _),
+        #(t.RightParen, _),
+        ..tokens
+      ] -> {
       let capture =
         FnCapture(Some(label), function, list.reverse(arguments), [])
       after_expression(capture, tokens)

--- a/test/glance_test.gleam
+++ b/test/glance_test.gleam
@@ -3365,4 +3365,11 @@ import gleam/list.{range} as _
 "
   |> glance.module()
   |> should.be_ok
+  |> fn(x: Module) { x.imports }
+  |> should.equal([
+    Definition(
+      [],
+      Import("gleam/list", Some("_"), [], [UnqualifiedImport("range", None)]),
+    ),
+  ])
 }

--- a/test/glance_test.gleam
+++ b/test/glance_test.gleam
@@ -472,7 +472,7 @@ pub fn aliased_import_test() {
   |> should.be_ok
   |> fn(x: Module) { x.imports }
   |> should.equal([
-    Definition([], Import("one/two/three", Some("four"), [], [])),
+    Definition([], Import("one/two/three", Some(Named("four")), [], [])),
   ])
 }
 
@@ -482,7 +482,7 @@ pub fn empty_unqualified_test() {
   |> should.be_ok
   |> fn(x: Module) { x.imports }
   |> should.equal([
-    Definition([], Import("one/two/three", Some("four"), [], [])),
+    Definition([], Import("one/two/three", Some(Named("four")), [], [])),
   ])
 }
 
@@ -494,7 +494,7 @@ pub fn unqualified_test() {
   |> should.equal([
     Definition(
       [],
-      Import("one/two/three", Some("four"), [], [
+      Import("one/two/three", Some(Named("four")), [], [
         UnqualifiedImport("One", None),
         UnqualifiedImport("Two", None),
         UnqualifiedImport("three", None),
@@ -514,7 +514,7 @@ pub fn unqualified_type_test() {
       [],
       Import(
         "one/two/three",
-        Some("four"),
+        Some(Named("four")),
         [
           UnqualifiedImport("One", None),
           UnqualifiedImport("Two", None),
@@ -535,7 +535,7 @@ pub fn unqualified_aliased_test() {
   |> should.equal([
     Definition(
       [],
-      Import("one/two/three", Some("four"), [], [
+      Import("one/two/three", Some(Named("four")), [], [
         UnqualifiedImport("One", Some("Two")),
         UnqualifiedImport("Three", None),
         UnqualifiedImport("four", Some("five")),
@@ -3361,7 +3361,7 @@ pub type X
 
 pub fn import_with_underscore_alias_test() {
   "
-import gleam/list.{range} as _
+import gleam/list.{range} as _alias
 "
   |> glance.module()
   |> should.be_ok
@@ -3369,7 +3369,9 @@ import gleam/list.{range} as _
   |> should.equal([
     Definition(
       [],
-      Import("gleam/list", Some("_"), [], [UnqualifiedImport("range", None)]),
+      Import("gleam/list", Some(Discarded("alias")), [], [
+        UnqualifiedImport("range", None),
+      ]),
     ),
   ])
 }

--- a/test/glance_test.gleam
+++ b/test/glance_test.gleam
@@ -1,6 +1,3 @@
-import gleeunit
-import gleeunit/should
-import gleam/option.{None, Some}
 import glance.{
   type Module, AddInt, And, Assert, Assignment, Attribute, BigOption,
   BinaryOperator, BinaryOption, BitString, BitStringOption, Block, Call, Case,
@@ -16,6 +13,9 @@ import glance.{
   UnsignedOption, Use, Utf16CodepointOption, Utf16Option, Utf32CodepointOption,
   Utf32Option, Utf8CodepointOption, Utf8Option, Variable, VariableType, Variant,
 }
+import gleam/option.{None, Some}
+import gleeunit
+import gleeunit/should
 import simplifile
 
 pub fn main() {
@@ -3357,4 +3357,12 @@ pub type X
       ),
     ),
   ])
+}
+
+pub fn import_with_underscore_alias_test() {
+  "
+import gleam/list.{range} as _
+"
+  |> glance.module()
+  |> should.be_ok
 }


### PR DESCRIPTION
```
Failures:

  1) glance_test.import_with_underscore_alias_test
     Failure: ?assertMatch({ ok , _ }, A)
       expected: = { ok , _ }
            got: {error,{unexpected_token,as,{position,27}}}
     output:
```