### PR TITLE
binary & bit_string renamed to bytes & bits

### DIFF
--- a/src/glance.gleam
+++ b/src/glance.gleam
@@ -1104,10 +1104,10 @@ fn bit_string_segment_options(
       }
     }
 
-    [#(t.Name("binary"), _), ..tokens] -> Ok(#(BinaryOption, tokens))
+    [#(t.Name("bytes"), _), ..tokens] -> Ok(#(BinaryOption, tokens))
     [#(t.Name("int"), _), ..tokens] -> Ok(#(IntOption, tokens))
     [#(t.Name("float"), _), ..tokens] -> Ok(#(FloatOption, tokens))
-    [#(t.Name("bit_string"), _), ..tokens] -> Ok(#(BitStringOption, tokens))
+    [#(t.Name("bits"), _), ..tokens] -> Ok(#(BitStringOption, tokens))
     [#(t.Name("utf8"), _), ..tokens] -> Ok(#(Utf8Option, tokens))
     [#(t.Name("utf16"), _), ..tokens] -> Ok(#(Utf16Option, tokens))
     [#(t.Name("utf32"), _), ..tokens] -> Ok(#(Utf32Option, tokens))

--- a/src/glance.gleam
+++ b/src/glance.gleam
@@ -1105,9 +1105,11 @@ fn bit_string_segment_options(
     }
 
     [#(t.Name("bytes"), _), ..tokens] -> Ok(#(BinaryOption, tokens))
+    [#(t.Name("binary"), _), ..tokens] -> Ok(#(BinaryOption, tokens))
     [#(t.Name("int"), _), ..tokens] -> Ok(#(IntOption, tokens))
     [#(t.Name("float"), _), ..tokens] -> Ok(#(FloatOption, tokens))
     [#(t.Name("bits"), _), ..tokens] -> Ok(#(BitStringOption, tokens))
+    [#(t.Name("bit_string"), _), ..tokens] -> Ok(#(BitStringOption, tokens))
     [#(t.Name("utf8"), _), ..tokens] -> Ok(#(Utf8Option, tokens))
     [#(t.Name("utf16"), _), ..tokens] -> Ok(#(Utf16Option, tokens))
     [#(t.Name("utf32"), _), ..tokens] -> Ok(#(Utf32Option, tokens))

--- a/test/glance_test.gleam
+++ b/test/glance_test.gleam
@@ -2018,7 +2018,7 @@ pub fn bit_string_units_test() {
 
 pub fn bit_string_others_test() {
   "pub fn main() { <<1, 2:
-binary-int-float-bit_string-utf8-utf16-utf32-utf8_codepoint-utf16_codepoint-utf32_codepoint-signed-unsigned-big-little-native
+bytes-int-float-bits-utf8-utf16-utf32-utf8_codepoint-utf16_codepoint-utf32_codepoint-signed-unsigned-big-little-native
 >> }"
   |> glance.module()
   |> should.be_ok
@@ -2027,7 +2027,7 @@ binary-int-float-bit_string-utf8-utf16-utf32-utf8_codepoint-utf16_codepoint-utf3
     Definition(
       [],
       Function(
-        location: Span(0, 154),
+        location: Span(0, 147),
         name: "main",
         publicity: Public,
         parameters: [],

--- a/test/glance_test.gleam
+++ b/test/glance_test.gleam
@@ -2018,7 +2018,7 @@ pub fn bit_string_units_test() {
 
 pub fn bit_string_others_test() {
   "pub fn main() { <<1, 2:
-bytes-int-float-bits-utf8-utf16-utf32-utf8_codepoint-utf16_codepoint-utf32_codepoint-signed-unsigned-big-little-native
+bytes-binary-int-float-bits-bit_string-utf8-utf16-utf32-utf8_codepoint-utf16_codepoint-utf32_codepoint-signed-unsigned-big-little-native
 >> }"
   |> glance.module()
   |> should.be_ok
@@ -2027,7 +2027,7 @@ bytes-int-float-bits-utf8-utf16-utf32-utf8_codepoint-utf16_codepoint-utf32_codep
     Definition(
       [],
       Function(
-        location: Span(0, 147),
+        location: Span(0, 165),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -2038,8 +2038,10 @@ bytes-int-float-bits-utf8-utf16-utf32-utf8_codepoint-utf16_codepoint-utf32_codep
               #(Int("1"), []),
               #(Int("2"), [
                 BinaryOption,
+                BinaryOption,
                 IntOption,
                 FloatOption,
+                BitStringOption,
                 BitStringOption,
                 Utf8Option,
                 Utf16Option,


### PR DESCRIPTION
Glance was still using the old syntax for these options. Should I rename any of the type names as well?

For reference, this syntax change was done when BitString was renamed to BitArray
https://gleam.run/news/v0.32-polishing-syntax-for-stability/
