### PR TITLE
update to glexer v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Updated to glexer v2.0.0
+
 ## v1.0.0 - 2024-09-30
 
 - Added support for `bits` and `bytes` bit string options.

--- a/gleam.toml
+++ b/gleam.toml
@@ -12,7 +12,7 @@ gleam = ">= 0.32.0"
 
 [dependencies]
 gleam_stdlib = ">= 0.28.0 and < 2.0.0"
-glexer = "~> 1.0"
+glexer = ">= 2.0.0 and < 3.0.0"
 
 [dev-dependencies]
 gleeunit = "~> 1.0"

--- a/manifest.toml
+++ b/manifest.toml
@@ -2,15 +2,15 @@
 # You typically do not need to edit this file
 
 packages = [
-  { name = "filepath", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "EFB6FF65C98B2A16378ABC3EE2B14124168C0CE5201553DE652E2644DCFDB594" },
-  { name = "gleam_stdlib", version = "0.37.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "5398BD6C2ABA17338F676F42F404B9B7BABE1C8DC7380031ACB05BBE1BCF3742" },
-  { name = "gleeunit", version = "1.1.2", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "72CDC3D3F719478F26C4E2C5FED3E657AC81EC14A47D2D2DEBB8693CA3220C3B" },
-  { name = "glexer", version = "1.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "7DDF490B891139BDE18F39A2A4DDE0683CBCB923F9472CD5C2C73DF1E56A6C13" },
+  { name = "filepath", version = "1.1.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "filepath", source = "hex", outer_checksum = "67A6D15FB39EEB69DD31F8C145BB5A421790581BD6AA14B33D64D5A55DBD6587" },
+  { name = "gleam_stdlib", version = "0.45.0", build_tools = ["gleam"], requirements = [], otp_app = "gleam_stdlib", source = "hex", outer_checksum = "206FCE1A76974AECFC55AEBCD0217D59EDE4E408C016E2CFCCC8FF51278F186E" },
+  { name = "gleeunit", version = "1.2.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "gleeunit", source = "hex", outer_checksum = "F7A7228925D3EE7D0813C922E062BFD6D7E9310F0BEE585D3A42F3307E3CFD13" },
+  { name = "glexer", version = "2.0.0", build_tools = ["gleam"], requirements = ["gleam_stdlib"], otp_app = "glexer", source = "hex", outer_checksum = "25E87F25706749E40C3CDC72D2E52AEA12260B23D14FD9E09A1B524EF393485E" },
   { name = "simplifile", version = "1.7.0", build_tools = ["gleam"], requirements = ["filepath", "gleam_stdlib"], otp_app = "simplifile", source = "hex", outer_checksum = "1D5DFA3A2F9319EC85825F6ED88B8E449F381B0D55A62F5E61424E748E7DDEB0" },
 ]
 
 [requirements]
 gleam_stdlib = { version = ">= 0.28.0 and < 2.0.0" }
 gleeunit = { version = "~> 1.0" }
-glexer = { version = "~> 1.0" }
+glexer = { version = ">= 2.0.0 and < 3.0.0" }
 simplifile = { version = "~> 1.0" }

--- a/src/glance.gleam
+++ b/src/glance.gleam
@@ -292,16 +292,10 @@ pub type Error {
 
 pub fn module(src: String) -> Result(Module, Error) {
   glexer.new(src)
+  |> glexer.discard_comments
+  |> glexer.discard_whitespace
   |> glexer.lex
-  |> list.filter(fn(pair) { !is_whitespace(pair.0) })
   |> slurp(Module([], [], [], [], []), [], _)
-}
-
-fn is_whitespace(token: Token) -> Bool {
-  case token {
-    t.EmptyLine | t.CommentNormal | t.CommentModule | t.CommentDoc(_) -> True
-    _ -> False
-  }
 }
 
 fn push_constant(
@@ -422,7 +416,6 @@ fn until(
 fn attribute(tokens: Tokens) -> Result(#(Attribute, Tokens), Error) {
   use #(name, tokens) <- result.try(case tokens {
     [#(t.Name(name), _), ..tokens] -> Ok(#(name, tokens))
-    [#(t.External, _), ..tokens] -> Ok(#("external", tokens))
     [#(other, position), ..] -> Error(UnexpectedToken(other, position))
     [] -> Error(UnexpectedEndOfInput)
   })

--- a/test/glance_test.gleam
+++ b/test/glance_test.gleam
@@ -843,7 +843,7 @@ pub fn function_parameters_test() {
     Definition(
       [],
       Function(
-        location: Span(0, 47),
+        location: Span(0, 49),
         name: "main",
         publicity: Private,
         parameters: [
@@ -1299,7 +1299,7 @@ pub fn expression_fn_discard_test() {
     Definition(
       [],
       Function(
-        location: Span(0, 32),
+        location: Span(0, 33),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -1718,7 +1718,7 @@ pub fn function_capture_pointless_test() {
     Definition(
       [],
       Function(
-        location: Span(0, 26),
+        location: Span(0, 27),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -1745,7 +1745,7 @@ pub fn function_capture_before_test() {
     Definition(
       [],
       Function(
-        location: Span(0, 32),
+        location: Span(0, 33),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -1776,7 +1776,7 @@ pub fn function_capture_after_test() {
     Definition(
       [],
       Function(
-        location: Span(0, 32),
+        location: Span(0, 33),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -1807,7 +1807,7 @@ pub fn function_capture_after_trailing_comma_test() {
     Definition(
       [],
       Function(
-        location: Span(0, 33),
+        location: Span(0, 34),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -1838,7 +1838,7 @@ pub fn function_capture_both_test() {
     Definition(
       [],
       Function(
-        location: Span(0, 35),
+        location: Span(0, 36),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -1865,7 +1865,7 @@ pub fn function_capture_immediate_call_test() {
     Definition(
       [],
       Function(
-        location: Span(0, 28),
+        location: Span(0, 29),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -2178,7 +2178,7 @@ pub fn discard_pattern_test() {
     Definition(
       [],
       Function(
-        location: Span(0, 29),
+        location: Span(0, 30),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -2198,7 +2198,7 @@ pub fn tuple_pattern_test() {
     Definition(
       [],
       Function(
-        location: Span(0, 31),
+        location: Span(0, 33),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -2225,7 +2225,7 @@ pub fn tuple_pattern_trailing_comma_test() {
     Definition(
       [],
       Function(
-        location: Span(0, 32),
+        location: Span(0, 34),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -2282,7 +2282,7 @@ pub fn concatenate_discard_pattern_test() {
     Definition(
       [],
       Function(
-        location: Span(0, 37),
+        location: Span(0, 38),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -3283,7 +3283,7 @@ pub fn label_capture_test() {
     Definition(
       [],
       Function(
-        location: Span(0, 31),
+        location: Span(0, 32),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -3314,7 +3314,7 @@ pub fn crash_test() {
     Definition(
       [],
       Function(
-        location: Span(0, 33),
+        location: Span(0, 34),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -3347,7 +3347,7 @@ pub fn main() {
     Definition(
       [],
       Function(
-        location: Span(1, 39),
+        location: Span(1, 40),
         name: "main",
         publicity: Public,
         parameters: [],
@@ -3484,7 +3484,7 @@ pub fn main() {
         publicity: Public,
         parameters: [],
         return: None,
-        body: [Expression(NegateInt(Int("11")))],
+        body: [Expression(Int("-11"))],
       ),
     ),
   ])


### PR DESCRIPTION
Updates to glexer `v2.0.0`. I noticed when running the test suite that a bunch of span ending positions no longer matched, but I _think_ after manual checking they were originally being reported wrong from glexer so I think this is an accidental bugfix?

Only important things to note that are different is
1. `token.External` has been dropped, but it looks like this doesn't impact glance.
2. `token.Int` now can contain negative numbers