### PR TITLE
fix precedence of negation operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixed the precedence of boolean and integer negation operators.
+
 ## v5.0.0 - 2025-05-24
 
 - All expressions have a location span as their first field.
@@ -35,7 +39,7 @@
 - Added support for label shorthand syntax.
 - `Field` now has two variants; `LabelledField` and `ShorthandField`.
 - `Variant` now uses a new `VariantField` type instead of `Field(Type)`.
-- `RecordUpdate` variant of `Expression` now uses a new `RecordUpdateField` 
+- `RecordUpdate` variant of `Expression` now uses a new `RecordUpdateField`
   type instead of `#(String, Expression)`.
 
 ## v1.1.0 - 2024-12-04

--- a/birdie_snapshots/expression_negate_bool_precedence.accepted
+++ b/birdie_snapshots/expression_negate_bool_precedence.accepted
@@ -1,0 +1,45 @@
+---
+version: 1.2.7
+title: expression_negate_bool_precedence
+file: ./test/glance_test.gleam
+test_name: expression_negate_bool_precedence_test
+---
+pub fn main() { !False && False }
+
+---------------------------
+
+Module(
+  [],
+  [],
+  [],
+  [],
+  [
+    Definition(
+      [],
+      Function(
+        Span(0, 33),
+        "main",
+        Public,
+        [],
+        None,
+        [
+          Expression(BinaryOperator(
+            Span(16, 31),
+            And,
+            NegateBool(
+              Span(16, 22),
+              Variable(
+                Span(17, 22),
+                "False",
+              ),
+            ),
+            Variable(
+              Span(26, 31),
+              "False",
+            ),
+          )),
+        ],
+      ),
+    ),
+  ],
+)

--- a/birdie_snapshots/expression_negate_int_precedence.accepted
+++ b/birdie_snapshots/expression_negate_int_precedence.accepted
@@ -1,0 +1,58 @@
+---
+version: 1.2.7
+title: expression_negate_int_precedence
+file: ./test/glance_test.gleam
+test_name: expression_negate_int_precedence_test
+---
+pub fn main() { let a = 1 echo -a + a }
+
+---------------------------
+
+Module(
+  [],
+  [],
+  [],
+  [],
+  [
+    Definition(
+      [],
+      Function(
+        Span(0, 39),
+        "main",
+        Public,
+        [],
+        None,
+        [
+          Assignment(
+            Span(16, 25),
+            Let,
+            PatternVariable(
+              Span(20, 21),
+              "a",
+            ),
+            None,
+            Int(Span(24, 25), "1"),
+          ),
+          Expression(Echo(
+            Span(26, 37),
+            Some(BinaryOperator(
+              Span(31, 37),
+              AddInt,
+              NegateInt(
+                Span(31, 33),
+                Variable(
+                  Span(32, 33),
+                  "a",
+                ),
+              ),
+              Variable(
+                Span(36, 37),
+                "a",
+              ),
+            )),
+          )),
+        ],
+      ),
+    ),
+  ],
+)

--- a/test/glance_test.gleam
+++ b/test/glance_test.gleam
@@ -498,10 +498,22 @@ pub fn expression_negate_int_test() {
   |> birdie.snap(title: "expression_negate_int")
 }
 
+pub fn expression_negate_int_precedence_test() {
+  "pub fn main() { let a = 1 echo -a + a }"
+  |> to_snapshot
+  |> birdie.snap(title: "expression_negate_int_precedence")
+}
+
 pub fn expression_negate_bool_test() {
   "pub fn main() { !x }"
   |> to_snapshot
   |> birdie.snap(title: "expression_negate_bool")
+}
+
+pub fn expression_negate_bool_precedence_test() {
+  "pub fn main() { !False && False }"
+  |> to_snapshot
+  |> birdie.snap(title: "expression_negate_bool_precedence")
 }
 
 pub fn expression_block_test() {


### PR DESCRIPTION
issue #35

Note: it looks like the float logic isn't needed anymore, parsing `-1.0` worked correctly when I tried it.