### PR TITLE
Fix typo in field name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- The `pattern` field of the `PatternAssignment` variant has been renamed from
+  the previous typo `attern`.
+
 ## v5.0.1 - 2025-08-25
 
 - Fixed the precedence of boolean and integer negation operators.

--- a/src/glance.gleam
+++ b/src/glance.gleam
@@ -73,7 +73,7 @@ pub type Pattern {
   PatternVariable(location: Span, name: String)
   PatternTuple(location: Span, elements: List(Pattern))
   PatternList(location: Span, elements: List(Pattern), tail: Option(Pattern))
-  PatternAssignment(location: Span, attern: Pattern, name: String)
+  PatternAssignment(location: Span, pattern: Pattern, name: String)
   PatternConcatenate(
     location: Span,
     prefix: String,


### PR DESCRIPTION
I noticed that the `pattern` field of the `PatternAssignment` was misspelled as `attern` so this PR fixes the typo