### PR TITLE
Parse prefix assignment with a discarded rest

### DIFF
--- a/birdie_snapshots/concatenate_pattern_with_prefix_assignment_and_discard.accepted
+++ b/birdie_snapshots/concatenate_pattern_with_prefix_assignment_and_discard.accepted
@@ -1,0 +1,42 @@
+---
+version: 1.2.7
+title: concatenate_pattern_with_prefix_assignment_and_discard
+file: ./test/glance_test.gleam
+test_name: concatenate_pattern_with_prefix_assignment_and_discard_test
+---
+pub fn main() { let "1" as x <> _ = "" }
+
+---------------------------
+
+Module(
+  [],
+  [],
+  [],
+  [],
+  [
+    Definition(
+      [],
+      Function(
+        Span(0, 40),
+        "main",
+        Public,
+        [],
+        None,
+        [
+          Assignment(
+            Span(16, 38),
+            Let,
+            PatternConcatenate(
+              Span(20, 33),
+              "1",
+              Some(Named("x")),
+              Discarded(""),
+            ),
+            None,
+            String(Span(36, 38), ""),
+          ),
+        ],
+      ),
+    ),
+  ],
+)

--- a/src/glance.gleam
+++ b/src/glance.gleam
@@ -985,6 +985,18 @@ fn pattern(tokens: Tokens) -> Result(#(Pattern, Tokens), Error) {
     }
     [
       #(t.String(v), P(start)),
+      #(t.As, _),
+      #(t.Name(l), _),
+      #(t.LessGreater, _),
+      #(t.DiscardName(r), P(name_start)),
+      ..tokens
+    ] -> {
+      let span = Span(start, string_offset(name_start, r) + 1)
+      let pattern = PatternConcatenate(span, v, Some(Named(l)), Discarded(r))
+      Ok(#(pattern, tokens))
+    }
+    [
+      #(t.String(v), P(start)),
       #(t.LessGreater, _),
       #(t.Name(n), P(name_start)),
       ..tokens

--- a/test/glance_test.gleam
+++ b/test/glance_test.gleam
@@ -858,6 +858,14 @@ pub fn concatenate_pattern_with_prefix_assignment_test() {
   |> birdie.snap(title: "concatenate_pattern_with_prefix_assignment")
 }
 
+pub fn concatenate_pattern_with_prefix_assignment_and_discard_test() {
+  "pub fn main() { let \"1\" as x <> _ = \"\" }"
+  |> to_snapshot
+  |> birdie.snap(
+    title: "concatenate_pattern_with_prefix_assignment_and_discard",
+  )
+}
+
 pub fn assignment_pattern_test() {
   "pub fn main() { let x as y = 1 }"
   |> to_snapshot


### PR DESCRIPTION
A string-prefix concatenation pattern that binds the prefix with `as` and discards the rest — e.g. `"a" as letter <> _` — fails to parse with `UnexpectedToken(LessGreater, ...)`, even though the Gleam compiler accepts it.

`pattern` already handles `"a" as x <> rest` (named rest) and `"a" <> _` (a discarded rest with no prefix assignment), but had no arm combining a prefix assignment with a discarded rest. This adds the missing `as Name <> Discarded`
arm.

Closes #44.