### PR TITLE
Parse arithmetic in bit-array pattern segment sizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+- Arithmetic in bit array pattern segment sizes can now be parsed.
+- `BitStringSegmentOption` now takes a type parameter for `SizeValueOption`.
+- The size value in pattern bit array segment options now uses the new
+  `BitArraySize` type.
+
 ## v6.1.0 - 2026-06-18
 
 - String prefix patterns that discard the rest can now be parsed.

--- a/birdie_snapshots/bit_string_expression_size_call.accepted
+++ b/birdie_snapshots/bit_string_expression_size_call.accepted
@@ -1,0 +1,48 @@
+---
+version: 1.2.7
+title: bit_string_expression_size_call
+file: ./test/glance_test.gleam
+test_name: bit_string_expression_size_call_test
+---
+pub fn main() { <<1:size(x())>> }
+
+---------------------------
+
+Module(
+  [],
+  [],
+  [],
+  [],
+  [
+    Definition(
+      [],
+      Function(
+        Span(0, 33),
+        "main",
+        Public,
+        [],
+        None,
+        [
+          Expression(BitString(
+            Span(16, 31),
+            [
+              #(
+                Int(Span(18, 19), "1"),
+                [
+                  SizeValueOption(Call(
+                    Span(25, 28),
+                    Variable(
+                      Span(25, 26),
+                      "x",
+                    ),
+                    [],
+                  )),
+                ],
+              ),
+            ],
+          )),
+        ],
+      ),
+    ),
+  ],
+)

--- a/birdie_snapshots/bit_string_pattern_arithmetic_size_options.accepted
+++ b/birdie_snapshots/bit_string_pattern_arithmetic_size_options.accepted
@@ -1,10 +1,10 @@
 ---
 version: 1.2.7
-title: bit_string_pattern_arithmetic_sizes
+title: bit_string_pattern_arithmetic_size_options
 file: ./test/glance_test.gleam
-test_name: bit_string_pattern_arithmetic_sizes_test
+test_name: bit_string_pattern_arithmetic_size_options_test
 ---
-pub fn main() { let <<v:size(len - 1), rest:bits>> = x }
+pub fn main() { let <<v:little-signed-size(n * 8)>> = x }
 
 ---------------------------
 
@@ -17,17 +17,17 @@ Module(
     Definition(
       [],
       Function(
-        Span(0, 56),
+        Span(0, 57),
         "main",
         Public,
         [],
         None,
         [
           Assignment(
-            Span(16, 54),
+            Span(16, 55),
             Let,
             PatternBitString(
-              Span(20, 50),
+              Span(20, 51),
               [
                 #(
                   PatternVariable(
@@ -35,31 +35,26 @@ Module(
                     "v",
                   ),
                   [
+                    LittleOption,
+                    SignedOption,
                     SizeValueOption(BitArraySizeBinaryOperator(
-                      Span(29, 36),
-                      BitArraySizeSubtract,
+                      Span(43, 48),
+                      BitArraySizeMultiply,
                       BitArraySizeVariable(
-                        Span(29, 32),
-                        "len",
+                        Span(43, 44),
+                        "n",
                       ),
                       BitArraySizeInt(
-                        Span(35, 36),
-                        "1",
+                        Span(47, 48),
+                        "8",
                       ),
                     )),
                   ],
                 ),
-                #(
-                  PatternVariable(
-                    Span(39, 43),
-                    "rest",
-                  ),
-                  [BitsOption],
-                ),
               ],
             ),
             None,
-            Variable(Span(53, 54), "x"),
+            Variable(Span(54, 55), "x"),
           ),
         ],
       ),

--- a/birdie_snapshots/bit_string_pattern_arithmetic_sizes.accepted
+++ b/birdie_snapshots/bit_string_pattern_arithmetic_sizes.accepted
@@ -1,0 +1,68 @@
+---
+version: 1.2.7
+title: bit_string_pattern_arithmetic_sizes
+file: ./test/glance_test.gleam
+test_name: bit_string_pattern_arithmetic_sizes_test
+---
+pub fn main() { let <<v:size(len - 1), rest:bits>> = x }
+
+---------------------------
+
+Module(
+  [],
+  [],
+  [],
+  [],
+  [
+    Definition(
+      [],
+      Function(
+        Span(0, 56),
+        "main",
+        Public,
+        [],
+        None,
+        [
+          Assignment(
+            Span(16, 54),
+            Let,
+            PatternBitString(
+              Span(20, 50),
+              [
+                #(
+                  PatternVariable(
+                    Span(22, 23),
+                    "v",
+                  ),
+                  [
+                    SizeValueOption(BinaryOperator(
+                      Span(29, 36),
+                      SubInt,
+                      Variable(
+                        Span(29, 32),
+                        "len",
+                      ),
+                      Int(
+                        Span(35, 36),
+                        "1",
+                      ),
+                    )),
+                  ],
+                ),
+                #(
+                  PatternVariable(
+                    Span(39, 43),
+                    "rest",
+                  ),
+                  [BitsOption],
+                ),
+              ],
+            ),
+            None,
+            Variable(Span(53, 54), "x"),
+          ),
+        ],
+      ),
+    ),
+  ],
+)

--- a/birdie_snapshots/bit_string_pattern_size_block.accepted
+++ b/birdie_snapshots/bit_string_pattern_size_block.accepted
@@ -1,0 +1,86 @@
+---
+version: 1.2.7
+title: bit_string_pattern_size_block
+file: ./test/glance_test.gleam
+test_name: bit_string_pattern_size_block_test
+---
+pub fn main() { let <<v:size({ len + 1 } * 8 + 1)>> = x }
+
+---------------------------
+
+Module(
+  [],
+  [],
+  [],
+  [],
+  [
+    Definition(
+      [],
+      Function(
+        Span(0, 57),
+        "main",
+        Public,
+        [],
+        None,
+        [
+          Assignment(
+            Span(16, 55),
+            Let,
+            PatternBitString(
+              Span(20, 51),
+              [
+                #(
+                  PatternVariable(
+                    Span(22, 23),
+                    "v",
+                  ),
+                  [
+                    SizeValueOption(BitArraySizeBinaryOperator(
+                      Span(29, 48),
+                      BitArraySizeAdd,
+                      BitArraySizeBinaryOperator(
+                        Span(29, 44),
+                        BitArraySizeMultiply,
+                        BitArraySizeBlock(
+                          Span(29, 40),
+                          BitArraySizeBinaryOperator(
+                            Span(31, 38),
+                            BitArraySizeAdd,
+                            BitArraySizeVariable(
+                              Span(
+                                31,
+                                34,
+                              ),
+                              "len",
+                            ),
+                            BitArraySizeInt(
+                              Span(
+                                37,
+                                38,
+                              ),
+                              "1",
+                            ),
+                          ),
+                        ),
+                        BitArraySizeInt(
+                          Span(43, 44),
+                          "8",
+                        ),
+                      ),
+                      BitArraySizeInt(
+                        Span(47, 48),
+                        "1",
+                      ),
+                    )),
+                  ],
+                ),
+              ],
+            ),
+            None,
+            Variable(Span(54, 55), "x"),
+          ),
+        ],
+      ),
+    ),
+  ],
+)

--- a/birdie_snapshots/bit_string_pattern_size_call_error.accepted
+++ b/birdie_snapshots/bit_string_pattern_size_call_error.accepted
@@ -1,0 +1,14 @@
+---
+version: 1.2.7
+title: bit_string_pattern_size_call_error
+file: ./test/glance_test.gleam
+test_name: bit_string_pattern_size_call_error_test
+---
+pub fn main() { let <<v:size(x())>> = x }
+
+---------------------------
+
+Error(UnexpectedToken(
+  LeftParen,
+  Position(30),
+))

--- a/src/glance.gleam
+++ b/src/glance.gleam
@@ -82,7 +82,7 @@ pub type Pattern {
   )
   PatternBitString(
     location: Span,
-    segments: List(#(Pattern, List(BitStringSegmentOption(Pattern)))),
+    segments: List(#(Pattern, List(BitStringSegmentOption))),
   )
   PatternVariant(
     location: Span,
@@ -130,7 +130,7 @@ pub type Expression {
   )
   BitString(
     location: Span,
-    segments: List(#(Expression, List(BitStringSegmentOption(Expression)))),
+    segments: List(#(Expression, List(BitStringSegmentOption))),
   )
 
   Case(location: Span, subjects: List(Expression), clauses: List(Clause))
@@ -155,7 +155,7 @@ pub type Clause {
   )
 }
 
-pub type BitStringSegmentOption(t) {
+pub type BitStringSegmentOption {
   BytesOption
   IntOption
   FloatOption
@@ -171,7 +171,7 @@ pub type BitStringSegmentOption(t) {
   BigOption
   LittleOption
   NativeOption
-  SizeValueOption(t)
+  SizeValueOption(Expression)
   SizeOption(Int)
   UnitOption(Int)
 }
@@ -1353,28 +1353,26 @@ fn todo_panic(
 fn bit_string_segment(
   parser: fn(Tokens) -> Result(#(t, Tokens), Error),
   tokens: Tokens,
-) -> Result(#(#(t, List(BitStringSegmentOption(t))), Tokens), Error) {
+) -> Result(#(#(t, List(BitStringSegmentOption)), Tokens), Error) {
   use #(value, tokens) <- result.try(parser(tokens))
-  let result = optional_bit_string_segment_options(parser, tokens)
+  let result = optional_bit_string_segment_options(tokens)
   use #(options, tokens) <- result.try(result)
   Ok(#(#(value, options), tokens))
 }
 
 fn optional_bit_string_segment_options(
-  parser: fn(Tokens) -> Result(#(t, Tokens), Error),
   tokens: Tokens,
-) -> Result(#(List(BitStringSegmentOption(t)), Tokens), Error) {
+) -> Result(#(List(BitStringSegmentOption), Tokens), Error) {
   case tokens {
-    [#(t.Colon, _), ..tokens] -> bit_string_segment_options(parser, [], tokens)
+    [#(t.Colon, _), ..tokens] -> bit_string_segment_options([], tokens)
     _ -> Ok(#([], tokens))
   }
 }
 
 fn bit_string_segment_options(
-  parser: fn(Tokens) -> Result(#(t, Tokens), Error),
-  options: List(BitStringSegmentOption(t)),
+  options: List(BitStringSegmentOption),
   tokens: Tokens,
-) -> Result(#(List(BitStringSegmentOption(t)), Tokens), Error) {
+) -> Result(#(List(BitStringSegmentOption), Tokens), Error) {
   use #(option, tokens) <- result.try(case tokens {
     // Size as just an int
     [#(t.Int(i), position), ..tokens] -> {
@@ -1384,9 +1382,10 @@ fn bit_string_segment_options(
       }
     }
 
-    // Size as an expression
+    // Size as an expression. The size is always an expression, even in a
+    // pattern segment, so that arithmetic such as `size(len - 1)` is accepted.
     [#(t.Name("size"), _), #(t.LeftParen, _), ..tokens] -> {
-      use #(value, tokens) <- result.try(parser(tokens))
+      use #(value, tokens) <- result.try(expression(tokens))
       use _, tokens <- expect(t.RightParen, tokens)
       Ok(#(SizeValueOption(value), tokens))
     }
@@ -1433,8 +1432,7 @@ fn bit_string_segment_options(
   let options = [option, ..options]
 
   case tokens {
-    [#(t.Minus, _), ..tokens] ->
-      bit_string_segment_options(parser, options, tokens)
+    [#(t.Minus, _), ..tokens] -> bit_string_segment_options(options, tokens)
     _ -> Ok(#(list.reverse(options), tokens))
   }
 }

--- a/src/glance.gleam
+++ b/src/glance.gleam
@@ -82,7 +82,7 @@ pub type Pattern {
   )
   PatternBitString(
     location: Span,
-    segments: List(#(Pattern, List(BitStringSegmentOption))),
+    segments: List(#(Pattern, List(BitStringSegmentOption(BitArraySize)))),
   )
   PatternVariant(
     location: Span,
@@ -130,7 +130,7 @@ pub type Expression {
   )
   BitString(
     location: Span,
-    segments: List(#(Expression, List(BitStringSegmentOption))),
+    segments: List(#(Expression, List(BitStringSegmentOption(Expression)))),
   )
 
   Case(location: Span, subjects: List(Expression), clauses: List(Clause))
@@ -155,7 +155,7 @@ pub type Clause {
   )
 }
 
-pub type BitStringSegmentOption {
+pub type BitStringSegmentOption(t) {
   BytesOption
   IntOption
   FloatOption
@@ -171,9 +171,29 @@ pub type BitStringSegmentOption {
   BigOption
   LittleOption
   NativeOption
-  SizeValueOption(Expression)
+  SizeValueOption(t)
   SizeOption(Int)
   UnitOption(Int)
+}
+
+pub type BitArraySize {
+  BitArraySizeInt(location: Span, value: String)
+  BitArraySizeVariable(location: Span, name: String)
+  BitArraySizeBinaryOperator(
+    location: Span,
+    operator: BitArraySizeOperator,
+    left: BitArraySize,
+    right: BitArraySize,
+  )
+  BitArraySizeBlock(location: Span, inner: BitArraySize)
+}
+
+pub type BitArraySizeOperator {
+  BitArraySizeAdd
+  BitArraySizeSubtract
+  BitArraySizeMultiply
+  BitArraySizeDivide
+  BitArraySizeRemainder
 }
 
 pub type BinaryOperator {
@@ -1046,7 +1066,7 @@ fn pattern(tokens: Tokens) -> Result(#(Pattern, Tokens), Error) {
     }
 
     [#(t.LessLess, P(start)), ..tokens] -> {
-      let parser = bit_string_segment(pattern, _)
+      let parser = bit_string_segment(pattern, bit_array_size, _)
       let result = comma_delimited([], tokens, parser, t.GreaterGreater)
       use #(segments, end, tokens) <- result.try(result)
       Ok(#(PatternBitString(Span(start, end), segments), tokens))
@@ -1284,7 +1304,7 @@ fn expression_unit(
     }
 
     [#(t.LessLess, P(start)), ..tokens] -> {
-      let parser = bit_string_segment(expression, _)
+      let parser = bit_string_segment(expression, expression, _)
       let result = comma_delimited([], tokens, parser, t.GreaterGreater)
       use #(segments, end, tokens) <- result.map(result)
       #(Some(BitString(Span(start, end), segments)), tokens)
@@ -1351,28 +1371,32 @@ fn todo_panic(
 }
 
 fn bit_string_segment(
-  parser: fn(Tokens) -> Result(#(t, Tokens), Error),
+  parser: fn(Tokens) -> Result(#(value, Tokens), Error),
+  size_parser: fn(Tokens) -> Result(#(size, Tokens), Error),
   tokens: Tokens,
-) -> Result(#(#(t, List(BitStringSegmentOption)), Tokens), Error) {
+) -> Result(#(#(value, List(BitStringSegmentOption(size))), Tokens), Error) {
   use #(value, tokens) <- result.try(parser(tokens))
-  let result = optional_bit_string_segment_options(tokens)
+  let result = optional_bit_string_segment_options(size_parser, tokens)
   use #(options, tokens) <- result.try(result)
   Ok(#(#(value, options), tokens))
 }
 
 fn optional_bit_string_segment_options(
+  size_parser: fn(Tokens) -> Result(#(size, Tokens), Error),
   tokens: Tokens,
-) -> Result(#(List(BitStringSegmentOption), Tokens), Error) {
+) -> Result(#(List(BitStringSegmentOption(size)), Tokens), Error) {
   case tokens {
-    [#(t.Colon, _), ..tokens] -> bit_string_segment_options([], tokens)
+    [#(t.Colon, _), ..tokens] ->
+      bit_string_segment_options(size_parser, [], tokens)
     _ -> Ok(#([], tokens))
   }
 }
 
 fn bit_string_segment_options(
-  options: List(BitStringSegmentOption),
+  size_parser: fn(Tokens) -> Result(#(size, Tokens), Error),
+  options: List(BitStringSegmentOption(size)),
   tokens: Tokens,
-) -> Result(#(List(BitStringSegmentOption), Tokens), Error) {
+) -> Result(#(List(BitStringSegmentOption(size)), Tokens), Error) {
   use #(option, tokens) <- result.try(case tokens {
     // Size as just an int
     [#(t.Int(i), position), ..tokens] -> {
@@ -1382,10 +1406,9 @@ fn bit_string_segment_options(
       }
     }
 
-    // Size as an expression. The size is always an expression, even in a
-    // pattern segment, so that arithmetic such as `size(len - 1)` is accepted.
+    // Size as an expression, or as a restricted bit array size in patterns.
     [#(t.Name("size"), _), #(t.LeftParen, _), ..tokens] -> {
-      use #(value, tokens) <- result.try(expression(tokens))
+      use #(value, tokens) <- result.try(size_parser(tokens))
       use _, tokens <- expect(t.RightParen, tokens)
       Ok(#(SizeValueOption(value), tokens))
     }
@@ -1432,8 +1455,127 @@ fn bit_string_segment_options(
   let options = [option, ..options]
 
   case tokens {
-    [#(t.Minus, _), ..tokens] -> bit_string_segment_options(options, tokens)
+    [#(t.Minus, _), ..tokens] ->
+      bit_string_segment_options(size_parser, options, tokens)
     _ -> Ok(#(list.reverse(options), tokens))
+  }
+}
+
+fn bit_array_size(tokens: Tokens) -> Result(#(BitArraySize, Tokens), Error) {
+  bit_array_size_loop(tokens, [], [])
+}
+
+fn bit_array_size_loop(
+  tokens: Tokens,
+  operators: List(BitArraySizeOperator),
+  values: List(BitArraySize),
+) -> Result(#(BitArraySize, Tokens), Error) {
+  use #(size, tokens) <- result.try(bit_array_size_unit(tokens))
+  let values = [size, ..values]
+
+  case pop_bit_array_size_operator(tokens) {
+    Ok(#(operator, tokens)) -> {
+      case handle_bit_array_size_operator(Some(operator), operators, values) {
+        #(Some(size), _, _) -> Ok(#(size, tokens))
+        #(None, operators, values) ->
+          bit_array_size_loop(tokens, operators, values)
+      }
+    }
+    Error(_) ->
+      case handle_bit_array_size_operator(None, operators, values).0 {
+        None -> unexpected_error(tokens)
+        Some(size) -> Ok(#(size, tokens))
+      }
+  }
+}
+
+fn bit_array_size_unit(tokens: Tokens) -> Result(#(BitArraySize, Tokens), Error) {
+  case tokens {
+    [#(t.Name(name), P(start)), ..tokens] ->
+      Ok(#(BitArraySizeVariable(span_from_string(start, name), name), tokens))
+
+    [#(t.Int(value), P(start)), ..tokens] ->
+      Ok(#(BitArraySizeInt(span_from_string(start, value), value), tokens))
+
+    [#(t.LeftBrace, P(start)), ..tokens] -> {
+      use #(inner, tokens) <- result.try(bit_array_size(tokens))
+      use P(end), tokens <- expect(t.RightBrace, tokens)
+      Ok(#(BitArraySizeBlock(Span(start, end + 1), inner), tokens))
+    }
+
+    [#(other, position), ..] -> Error(UnexpectedToken(other, position))
+    [] -> Error(UnexpectedEndOfInput)
+  }
+}
+
+fn bit_array_size_operator(token: Token) -> Result(BitArraySizeOperator, Nil) {
+  case token {
+    t.Plus -> Ok(BitArraySizeAdd)
+    t.Minus -> Ok(BitArraySizeSubtract)
+    t.Star -> Ok(BitArraySizeMultiply)
+    t.Slash -> Ok(BitArraySizeDivide)
+    t.Percent -> Ok(BitArraySizeRemainder)
+    _ -> Error(Nil)
+  }
+}
+
+fn bit_array_size_precedence(operator: BitArraySizeOperator) -> Int {
+  case operator {
+    BitArraySizeAdd | BitArraySizeSubtract -> 7
+    BitArraySizeMultiply | BitArraySizeDivide | BitArraySizeRemainder -> 8
+  }
+}
+
+fn pop_bit_array_size_operator(
+  tokens: Tokens,
+) -> Result(#(BitArraySizeOperator, Tokens), Nil) {
+  case tokens {
+    [#(token, _), ..tokens] -> {
+      use operator <- result.map(bit_array_size_operator(token))
+      #(operator, tokens)
+    }
+    [] -> Error(Nil)
+  }
+}
+
+fn handle_bit_array_size_operator(
+  next: Option(BitArraySizeOperator),
+  operators: List(BitArraySizeOperator),
+  values: List(BitArraySize),
+) -> #(Option(BitArraySize), List(BitArraySizeOperator), List(BitArraySize)) {
+  case next, operators, values {
+    Some(operator), [], _ -> #(None, [operator], values)
+
+    Some(next), [previous, ..operators], [a, b, ..rest_values] -> {
+      case
+        bit_array_size_precedence(previous) >= bit_array_size_precedence(next)
+      {
+        True -> {
+          let span = Span(b.location.start, a.location.end)
+          let size = BitArraySizeBinaryOperator(span, previous, b, a)
+          let values = [size, ..rest_values]
+          handle_bit_array_size_operator(Some(next), operators, values)
+        }
+        False -> #(None, [next, previous, ..operators], values)
+      }
+    }
+
+    None, [operator, ..operators], [a, b, ..values] -> {
+      let values = [
+        BitArraySizeBinaryOperator(
+          Span(b.location.start, a.location.end),
+          operator,
+          b,
+          a,
+        ),
+        ..values
+      ]
+      handle_bit_array_size_operator(None, operators, values)
+    }
+
+    None, [], [size] -> #(Some(size), operators, values)
+    None, [], [] -> #(None, operators, values)
+    _, _, _ -> panic as "parser bug, bit array size not fully reduced"
   }
 }
 

--- a/test/glance_test.gleam
+++ b/test/glance_test.gleam
@@ -754,10 +754,34 @@ pub fn bit_string_value_sizes_test() {
   |> birdie.snap(title: "bit_string_value_sizes")
 }
 
+pub fn bit_string_expression_size_call_test() {
+  "pub fn main() { <<1:size(x())>> }"
+  |> to_snapshot
+  |> birdie.snap(title: "bit_string_expression_size_call")
+}
+
 pub fn bit_string_pattern_arithmetic_sizes_test() {
   "pub fn main() { let <<v:size(len - 1), rest:bits>> = x }"
   |> to_snapshot
   |> birdie.snap(title: "bit_string_pattern_arithmetic_sizes")
+}
+
+pub fn bit_string_pattern_arithmetic_size_options_test() {
+  "pub fn main() { let <<v:little-signed-size(n * 8)>> = x }"
+  |> to_snapshot
+  |> birdie.snap(title: "bit_string_pattern_arithmetic_size_options")
+}
+
+pub fn bit_string_pattern_size_block_test() {
+  "pub fn main() { let <<v:size({ len + 1 } * 8 + 1)>> = x }"
+  |> to_snapshot
+  |> birdie.snap(title: "bit_string_pattern_size_block")
+}
+
+pub fn bit_string_pattern_size_call_error_test() {
+  "pub fn main() { let <<v:size(x())>> = x }"
+  |> to_snapshot
+  |> birdie.snap(title: "bit_string_pattern_size_call_error")
 }
 
 pub fn bit_string_units_test() {

--- a/test/glance_test.gleam
+++ b/test/glance_test.gleam
@@ -754,6 +754,12 @@ pub fn bit_string_value_sizes_test() {
   |> birdie.snap(title: "bit_string_value_sizes")
 }
 
+pub fn bit_string_pattern_arithmetic_sizes_test() {
+  "pub fn main() { let <<v:size(len - 1), rest:bits>> = x }"
+  |> to_snapshot
+  |> birdie.snap(title: "bit_string_pattern_arithmetic_sizes")
+}
+
 pub fn bit_string_units_test() {
   "pub fn main() { <<1, 2:unit(5), 5:unit(3)>> }"
   |> to_snapshot


### PR DESCRIPTION
A bit-array pattern whose segment `size` is an arithmetic expression, e.g. `<<v:size(len - 1)>>` or `<<v:little-signed-size(n * 8)>>` 👉  `UnexpectedToken(Star, ...)`.

Two things worth noting:
- This must be a breaking change. Noted in the `CHANGELOG.md` (Under `[Unreleased]` section).
- ~I took a shortcut. Instead of creating a type `BitArraySize` like the _Gleam_ parser does, I reused `Expression`. In other words, this parses a superset of invalid code, like `...:size(f(x))`. Should I walk down this path? (I mean, create the `BitArraySize` with the restricted expression set).~ The size value in pattern bit array segment options now uses the a new `BitArraySize` type, which mirrors the Gleam compiler one.

Closes #43